### PR TITLE
Add assumption environment and corresponding label/reference commands

### DIFF
--- a/examples/documentation/chapters/references.tex
+++ b/examples/documentation/chapters/references.tex
@@ -184,6 +184,7 @@ many typically labeled elements, including:
 	\item Figure: \Command{labfig}
 	\item Table: \Command{labtab}
 	\item Definition: \Command{labdef}
+	\item Assumption: \Command{labassum}
 	\item Theorem: \Command{labthm}
 	\item Proposition: \Command{labprop}
 	\item Lemma: \Command{lablemma}

--- a/styles/kaorefs.sty
+++ b/styles/kaorefs.sty
@@ -48,6 +48,7 @@
 \newcommand{\eqname}{}
 \newcommand{\eqnameshort}{}
 \newcommand{\defname}{}
+\newcommand{\assumname}{}
 \newcommand{\thmname}{}
 \newcommand{\propname}{}
 \newcommand{\lemmaname}{}
@@ -66,6 +67,7 @@
   \renewcommand{\eqname}{Equation}
   \renewcommand{\eqnameshort}{Eq.}
   \renewcommand{\defname}{Definition}
+  \renewcommand{\assumname}{Assumption}
   \renewcommand{\thmname}{Theorem}
   \renewcommand{\propname}{Proposition}
   \renewcommand{\lemmaname}{Lemma}
@@ -84,6 +86,7 @@
   \renewcommand{\eqname}{Equazione}
   \renewcommand{\eqnameshort}{Eq.}
   \renewcommand{\defname}{Definizione}
+  \renewcommand{\assumname}{Assunzione}
   \renewcommand{\thmname}{Teorema}
   \renewcommand{\propname}{Proposizione}
   \renewcommand{\lemmaname}{Lemma}
@@ -105,6 +108,7 @@
 \newcommand{\labeq}[1]{\label{eq:#1}}
 \newcommand{\labdef}[1]{\label{def:#1}}
 \newcommand{\labthm}[1]{\label{thm:#1}}
+\newcommand{\labassum}[1]{\label{assum:#1}}
 \newcommand{\labprop}[1]{\label{prop:#1}}
 \newcommand{\lablemma}[1]{\label{lemma:#1}}
 \newcommand{\labremark}[1]{\label{remark:#1}}
@@ -161,6 +165,9 @@
 
 \newcommand{\refdef}[1]{\hyperref[def:#1]\defname\xspace\ref{def:#1}}
 \newcommand{\vrefdef}[1]{\hyperref[def:#1]\defname\xspace\vref{def:#1}}
+
+\newcommand{\refassum}[1]{\hyperref[assum:#1]\assumname\xspace\ref{assum:#1}}
+\newcommand{\vrefassum}[1]{\hyperref[assum:#1]\assumname\xspace\vref{assum:#1}}
 
 \newcommand{\refthm}[1]{\hyperref[thm:#1]\thmname\xspace\ref{thm:#1}}
 \newcommand{\vrefthm}[1]{\hyperref[thm:#1]\thmname\xspace\vref{thm:#1}}

--- a/styles/mdftheorems.sty
+++ b/styles/mdftheorems.sty
@@ -34,6 +34,7 @@
 \newcommand{\@lemmabackground}{\@background}
 \newcommand{\@corollarybackground}{\@background}
 \newcommand{\@definitionbackground}{\@background}
+\newcommand{\@assumptionbackground}{\@background}
 \newcommand{\@remarkbackground}{\@background}
 \newcommand{\@examplebackground}{\@background}
 
@@ -55,6 +56,9 @@
 }
 \DeclareOptionX{definitionbackground}{%
 	\renewcommand{\@definitionbackground}{#1}%
+}
+\DeclareOptionX{assumptionbackground}{%
+	\renewcommand{\@assumptionbackground}{#1}%
 }
 \DeclareOptionX{remarkbackground}{%
 	\renewcommand{\@remarkbackground}{#1}%
@@ -118,6 +122,18 @@
 	postheadspace={.5em plus .1em minus .1em},
 	%prefoothook={\hfill\qedsymbol}
 ]{kaodefinition}
+
+\declaretheoremstyle[
+	%spaceabove=.5\thm@preskip,
+	%spacebelow=.5\thm@postskip,
+	%headfont=\normalfont\bfseries,%\scshape,
+	%notefont=\normalfont, notebraces={ (}{)},
+	bodyfont=\normalfont\itshape,
+	%headformat={\NAME\space\NUMBER\space\NOTE},
+	headpunct={},
+	postheadspace={.5em plus .1em minus .1em},
+	%prefoothook={\hfill\qedsymbol}
+]{kaoassumption}
 
 \declaretheoremstyle[
 	%spaceabove=.5\thm@preskip,
@@ -206,6 +222,19 @@
 		%frametitlebackgroundcolor=\@theorembackground,
 	},
 ]{definition}
+
+\theoremstyle{kaoassumption}
+\declaretheorem[
+	name=Assumption,
+	refname={assumption,assumptions},
+	Refname={Assumption,Assumptions},
+	numberwithin=section,
+	mdframed={
+		style=mdfkao,
+		backgroundcolor=\@assumptionbackground,
+		%frametitlebackgroundcolor=\@theorembackground,
+	},
+]{assumption}
 
 \theoremstyle{kaoremark}
 \declaretheorem[


### PR DESCRIPTION
I figured having an `assumption` environment could be useful for others like how the existing `definition`, `remark`, etc. environments are useful.