### PR TITLE
Add option to change section numbering depth

### DIFF
--- a/book-template.tex
+++ b/book-template.tex
@@ -29,6 +29,7 @@
 	fontsize=10pt, % Base font size
 	twoside=false, % Use different layouts for even and odd pages (in particular, if twoside=true, the margin column will be always on the outside)
 	%open=any, % If twoside=true, uncomment this to force new chapters to start on any page, not only on right (odd) pages
+	secnumdepth=1, % How deep to number headings. Defaults to 1 (sections)
 	%chapterprefix=true, % Uncomment to use the word "Chapter" before chapter numbers everywhere they appear
 	%chapterentrydots=true, % Uncomment to output dots from the chapter name to the page number in the table of contents
 	numbers=noenddot, % Comment to output dots after chapter numbers; the most common values for this option are: enddot, noenddot and auto (see the KOMAScript documentation for an in-depth explanation)

--- a/examples/documentation/chapters/layout.tex
+++ b/examples/documentation/chapters/layout.tex
@@ -164,8 +164,11 @@ example, when I start a new part, I write:
 In this short section we shall see how dispositions, sidenotes and 
 figures are numbered in the \Class{kaobook} class.
 
-By default, dispositions are numbered up to the section. This is 
-achieved by setting: \lstinline|\setcounter{secnumdepth}{1}|.
+By default, dispositions are numbered up to the section in \Class{kaobook}
+and up to the subsection in \Class{kaohandt}. This can be changed by
+passing the option \Option{secnumdepth} to\Class{kaobook} or
+\Class{kaohandt} (e.g. 1 corresponds to section and 2 corresponds to
+subsections).
 
 The sidenotes counter is the same across all the document, but if you 
 want it to reset at each chapter, just uncomment the line

--- a/kaobook.cls
+++ b/kaobook.cls
@@ -27,6 +27,8 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{kaobook}[2020/03/12 v1.1 kaobook]
 
+\RequirePackage{xkeyval} % Manage class key-value options
+
 \newcommand{\@classname}{kaobook} % Class name
 \newcommand{\@baseclass}{scrbook} % Base class name
 
@@ -35,9 +37,14 @@
 \PassOptionsToClass{parskip=half}{\@baseclass}
 \PassOptionsToClass{headings=optiontoheadandtoc}{\@baseclass}
 
-\DeclareOption*{\PassOptionsToClass{\CurrentOption}{\@baseclass}} % Pass through any options to the base class
+\newcommand{\@secnumdepth}{1} % Set default numbering depth up to sections
+\DeclareOptionX{secnumdepth}{% % Declare secnumdepth as an option
+	\renewcommand{\@secnumdepth}{#1}%
+}
 
-\ProcessOptions\relax % Process the options
+\DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{\@baseclass}} % Pass through any options to the base class
+
+\ProcessOptionsX\relax % Process the options
 
 \LoadClass{\@baseclass} % Load the base class
 \RequirePackage{styles/kao} % Load the code common to all classes
@@ -267,7 +274,7 @@
 %	NUMBERING
 %----------------------------------------------------------------------------------------
 
-\setcounter{secnumdepth}{1} % Number only up to sections
+\setcounter{secnumdepth}{\@secnumdepth} % Set section numbering depth
 
 \counterwithin*{sidenote}{chapter} % Uncomment to reset the sidenote counter at each chapter
 %\counterwithout{sidenote}{chapter} % Uncomment to have one sidenote counter for the whole document

--- a/kaohandt.cls
+++ b/kaohandt.cls
@@ -27,12 +27,19 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{kaohandt}[2019/06/05 v1.0 kaohandt class v1.0]
 
+\RequirePackage{xkeyval} % Manage class key-value options
+
 \newcommand{\@classname}{kaobook} % Class name
 \newcommand{\@baseclass}{scrartcl} % Base class name
 
+\newcommand{\@secnumdepth}{2} % Set default numbering depth up to subsections
+\DeclareOptionX{secnumdepth}{% % Declare secnumdepth as an option
+	\renewcommand{\@secnumdepth}{#1}%
+}
+
 % Set the default options
-\DeclareOption*{\PassOptionsToClass{\CurrentOption}{\@baseclass}} % Pass through any options to the base class
-\ProcessOptions\relax % Process the options
+\DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{\@baseclass}} % Pass through any options to the base class
+\ProcessXOptions\relax % Process the options
 \LoadClass{\@baseclass} % Load the base class
 \input{styles/kao.sty} % Load the code common to all classes
 
@@ -78,7 +85,7 @@
 %	NUMBERING
 %----------------------------------------------------------------------------------------
 
-\setcounter{secnumdepth}{2} % Number up to subsections
+\setcounter{secnumdepth}{\@secnumdepth} % Set section numbering depth
 
 \counterwithin*{sidenote}{section} % Uncomment to reset the sidenote counter at each section
 %\counterwithout{sidenote}{section} % Uncomment to have one sidenote counter for the whole document

--- a/report-template.tex
+++ b/report-template.tex
@@ -28,6 +28,7 @@
 \documentclass[
 	%fontsize=10pt, % Base font size
 	%twoside=false, % If true, use different layouts for even and odd pages (in particular, if twoside=true, the margin column will be always on the outside)
+	%secnumdepth=2, % How deep to number headings. Defaults to 2 (subsections)
 	%abstract=true, % Uncomment to print the title of the abstract
 	%numbers=noenddot, % Comment to output dots after section numbers; the most common values for this option are: enddot, noenddot and auto (see the KOMAScript documentation for an in-depth explanation)
 	%draft=true, % If uncommented, rulers will be added in the header and footer


### PR DESCRIPTION
This will allow people to choose what depth they want their section numbering to go to via an option. This has been tested on Overleaf with `kaobook`, but not with `kaohandt`.