### PR TITLE
Capitalize declared theorems to match cleveref default capitalise option

### DIFF
--- a/styles/mdftheorems.sty
+++ b/styles/mdftheorems.sty
@@ -167,7 +167,8 @@
 \declaretheorem[
 	name=Theorem,
 	style=kaoplain,
-	refname={theorem,theorems},
+	%refname={theorem,theorems},
+	refname={Theorem,Theorems},
 	Refname={Theorem,Theorems},
 	numberwithin=section,
 	mdframed={
@@ -178,7 +179,8 @@
 ]{theorem}
 \declaretheorem[
 	name=Proposition,
-	refname={proposition,propositions},
+	%refname={proposition,propositions},
+	refname={Proposition,Propositions},
 	Refname={Proposition,Propositions},
 	sibling=theorem,
 	mdframed={
@@ -189,7 +191,8 @@
 ]{proposition}
 \declaretheorem[
 	name=Lemma,
-	refname={lemma,lemmas},
+	%refname={lemma,lemmas},
+	refname={Lemma,Lemmas},
 	Refname={Lemma,Lemmas},
 	sibling=theorem,
 	mdframed={
@@ -200,7 +203,8 @@
 ]{lemma}
 \declaretheorem[
 	name=Corollary,
-	refname={corollary,corollaries},
+	%refname={corollary,corollaries},
+	refname={Corollary,Corollaries},
 	Refname={Corollary,Corollaries},
 	sibling=theorem,
 	mdframed={
@@ -213,7 +217,8 @@
 \theoremstyle{kaodefinition}
 \declaretheorem[
 	name=Definition,
-	refname={definition,definitions},
+	%refname={definition,definitions},
+	refname={Definition,Definitions},
 	Refname={Definition,Definitions},
 	numberwithin=section,
 	mdframed={
@@ -226,7 +231,8 @@
 \theoremstyle{kaoassumption}
 \declaretheorem[
 	name=Assumption,
-	refname={assumption,assumptions},
+	%refname={assumption,assumptions},
+	refname={Assumption,Assumptions},
 	Refname={Assumption,Assumptions},
 	numberwithin=section,
 	mdframed={
@@ -239,7 +245,8 @@
 \theoremstyle{kaoremark}
 \declaretheorem[
 	name=Remark,
-	refname={remark,remarks},
+	%refname={remark,remarks},
+	refname={Remark,Remarks},
 	Refname={Remark,Remarks},
 	numberwithin=section,
 	mdframed={
@@ -252,7 +259,8 @@
 \theoremstyle{kaoexample}
 \declaretheorem[
 	name=Example,
-	refname={example,examples},
+	%refname={example,examples},
+	refname={Example,Examples},
 	Refname={Example,Examples},
 	numberwithin=section,
 	mdframed={


### PR DESCRIPTION
Support for `cleveref` was added recently (see #51 and recent commits). It is used with the `capitalise` option, which produces section references like "Section 4.3" when using `\cref{sec:4.3}`. However, the `refname` field for `\declaretheorem` in `styles/mdftheorems.sty` overwrites this behavior to something like "definition 2.3" instead of "Definition 2.3" when using `\cref{def:2.3}`. This commit fixes that, capitalizing all the references to environments declared in `styles/mdftheorems.sty`.