### PR TITLE
Fixes #98

### DIFF
--- a/kaobook.cls
+++ b/kaobook.cls
@@ -123,19 +123,17 @@
 	\setlength{\mtocshift}{-1\vscale}
 }
 
-\newlength{\kao@chfsize}% Store the dimension of the font used for chapter. It is used to increase the size of the vertical rule of a size equal to that, so that the rule protrudes of that length into the frame of the main text.
 
 % The Kao style
 \DeclareDocumentCommand{\chapterstylekao}{}{%
 	\renewcommand*{\chapterformat}{%
 		\mbox{\chapappifchapterprefix{\nobreakspace}\scalebox{2.85}{\thechapter\autodot}}%
 	}%
-	\setlength{\kao@chfsize}{\dimexpr 1mm * \f@size\relax}%
 	\renewcommand\chapterlinesformat[3]{%
 		\vspace{3.5\vscale}%
 		\smash{\makebox[0pt][l]{%
 			\parbox[b]{\textwidth}{\flushright{##3}}%
-			\makebox[\marginparsep][c]{\rule[-2\vscale]{1pt}{27.4\vscale+\kao@chfsize}}%
+			\makebox[\marginparsep][c]{\rule[-2\vscale]{1pt}{27.4\vscale+\f@size mm}}%
 			\parbox[b]{\marginparwidth}{##2}%
 		}}%
 	}%


### PR DESCRIPTION
This change should fix #98.

```\kao@chfsize``` is only used once so I skip the generation of the variable.
To convert to ```mm``` I use  ```\f@size mm``` instead of ```\dimexpr 1mm * \f@size\relax```.

I am not sure whether this is the best way to do this, but it seems to fix the problem :smiley: