### PR TITLE
Fixes #134 (for TeXLive 2021)

### DIFF
--- a/kao.sty
+++ b/kao.sty
@@ -1034,11 +1034,11 @@
 	\RequirePackage[utf8]{inputenc} % utf8 encoding in the input (.tex) file
 	\RequirePackage[T1]{fontenc} % utf8 encoding in the output (.pdf) file
 
+	\RequirePackage{amssymb} % Math symbols, including \blacktriangleright, used for bullets
 	\RequirePackage[scaled=.97,helvratio=.93,p,theoremfont]{newpxtext} % Serif palatino font
 	\RequirePackage[vvarbb,smallerops,bigdelims]{newpxmath} % Math palatino font
 	\RequirePackage[scaled=.85]{beramono} % Monospace font
 	\RequirePackage[scr=rsfso,cal=boondoxo]{mathalfa} % Mathcal from STIX, unslanted a bit
-	\RequirePackage{amssymb} % Math symbols, including \blacktriangleright, used for bullets
     \RequirePackage{morewrites} % Fix some errors related to floats
 \fi
 


### PR DESCRIPTION
This small change seems to let kaobook work with TeXLive 2021, where it was failing to compile any document before.  The issue #134 describes why.  I asked there if making a change like this works for others, and @AlexanderZeilmann said it did.  I only tested it against `pdflatex` (and `latex` just now), but the `\ifxetexorluatex` case looks like it already does something similar so I think it's fine.

This is my first pull request (and I think the first time I've pushed something to a forked repo), so please let me know if I've done anything wrong.  I wasn't totally sure if I should have created a separate branch for this, for example.  (I decided not to, but not sure if I made the right choice there.)  Again, thank you for your work on this project.