### PR TITLE
Fix for issue #127

### DIFF
--- a/kao.sty
+++ b/kao.sty
@@ -701,7 +701,7 @@
 		capbesidesep=marginparsep,%
 		floatwidth=\textwidth,%Width of the figure equal to the width of the text
 	}%
-	\captionsetup[lstlisting]{%
+	\captionsetup*[lstlisting]{%
 		format=llap,%
 		labelsep=space,%
 		singlelinecheck=no,%
@@ -765,7 +765,7 @@
 		capbesidesep=marginparsep,%
 		floatwidth=\textwidth,% Width of the figure equal to the width of the text
 	}%
-	\captionsetup[lstlisting]{%
+	\captionsetup*[lstlisting]{%
 		format=llap,%
 		labelsep=space,%
 		singlelinecheck=no,%
@@ -806,7 +806,7 @@
 		margins=centering,%
 		floatwidth=\textwidth%
 	}
-	\captionsetup[lstlisting]{% Captions style for lstlistings
+	\captionsetup*[lstlisting]{% Captions style for lstlistings
 		%format=margin,%
 		labelsep=colon,%
 		strut=no,%


### PR DESCRIPTION
The warning message can be silenced by changing \captionsetup[...] to
\captionsetup*[...] as per the cation documentation on page 45.

Fixes #127