### PR TITLE
Fix typos and a link in `README.md`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ As a contributor, you are expected to follow the [code of conduct](https://githu
 Please read it and comply with the rules.
 
 ### Ways to Contribute
-*  Use ```kaobook``` and write [bug repots](https://github.com/fmarotta/kaobook/issues/new?assignees=&labels=&template=bug_report.md) or [feature requests](https://github.com/AlexanderZeilmann/kaobook/issues/new?assignees=&labels=&template=feature_request.md).
+*  Use ```kaobook``` and write [bug reports](https://github.com/fmarotta/kaobook/issues/new?assignees=&labels=&template=bug_report.md) or [feature requests](https://github.com/AlexanderZeilmann/kaobook/issues/new?assignees=&labels=&template=feature_request.md).
 *  Have a look at our [issues](https://github.com/fmarotta/kaobook/issues) and especially at our ["help wanted" issues](https://github.com/fmarotta/kaobook/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22). Maybe you can help out with one of them.
 *  Help improving our [documentation](https://github.com/fmarotta/kaobook/blob/master/example_and_documentation.pdf).
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@
 This class is based on the work of [Ken Arroyo
 Ohori](https://3d.bk.tudelft.nl/ken/en/) for his doctoral thesis.
 The main ideas behind the layout can be found in this [blog
-post](https://3d.bk.tudelft.nl/ken/en/2016/04/17/a-1.5-column-layout-in-
-latex.html). The [Tufte-LaTeX
-class](https://github.com/Tufte-LaTeX/tufte-latex) has also been a
+post](https://3d.bk.tudelft.nl/ken/en/2016/04/17/a-1.5-column-layout-in-latex.html).
+The [Tufte-LaTeX class](https://github.com/Tufte-LaTeX/tufte-latex) has also been a
 source of ideas about the layout.
 
 My gratitude goes also to [Vel](https://www.vel.nz/), for his patience 
@@ -138,7 +137,7 @@ position of each element; this is true in particular for the positioning
 of floating elements like figures, tables, and margin notes.
 Occasionally, LaTeX can need up to four re-runs, so If the alignment of
 margin elements looks odd, or if they bleed into ther main text, try
-runnign pdflatex one more time.
+running pdflatex one more time.
 
 ## Updating kaobook
 
@@ -211,7 +210,7 @@ formatted blocks.
 I am always happy to help as much as I can, and I am glad if someone
 uses the `kaobook` class for their works, so there is no real need to do
 anything: the kaobook can be used just like any other LaTeX package (no 
-need to add copyright statements). However, if you want to aknowledge 
+need to add copyright statements). However, if you want to acknowledge 
 kaobook, adding somewhere a sentence like 'This book was typeset with the
 kaobook class' would suffice.
 

--- a/examples/documentation/chapters/layout.tex
+++ b/examples/documentation/chapters/layout.tex
@@ -90,7 +90,7 @@ always, any help will be greatly appreciated.
 
 By passing the \Option{twoside} option to the \Class{kaobook}, the
 style of left and right pages will be different, similarly to a
-printed book. In digital books, having a simmetrical layout for
+printed book. In digital books, having a symmetrical layout for
 left and right pages is less important, and you may be tempted
 to use the \Option{twoside=false} option. However, keep in mind
 that in \enquote{oneside} mode the \Command{uppertitleback} and

--- a/examples/documentation/chapters/references.tex
+++ b/examples/documentation/chapters/references.tex
@@ -319,4 +319,4 @@ correct position of each element; this is true in particular for the
 positioning of floating elements like figures, tables, and margin notes.
 Occasionally, \LaTeX\ can need up to four re-runs, so If the alignment
 of margin elements looks odd, or if they bleed into ther main text, try
-runnign pdflatex one more time.
+running pdflatex one more time.


### PR DESCRIPTION
This PR fixes a few assorted typos and more importantly, the broken link due to a line-break in `README.md`.