### PR TITLE
Test examples compile in CI using `latexmk`

### DIFF
--- a/.github/workflows/verify_examples.yml
+++ b/.github/workflows/verify_examples.yml
@@ -1,0 +1,37 @@
+name: Verify examples
+on: [push, pull_request]
+
+jobs:
+  find_examples:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.find-dirs.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Gather directories inside examples
+        id: find-dirs
+        run: |
+          cd examples
+          echo "::set-output name=matrix::{\"dir\":[$(for dir in $(echo */); do echo -n \"${dir%?}\",; done)]}"
+  build_latex:
+    needs: find_examples
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{fromJson(needs.find_examples.outputs.matrix)}}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check that LaTeX example compiles
+        uses: xu-cheng/latex-action@v2
+        with:
+          working_directory: examples/${{ matrix.dir }}
+          pre_compile: |
+            cp ../../* . || true
+            mkdir styles && cp ../../* ./styles/ || true
+          root_file: main.tex
+          latexmk_shell_escape: true
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: Log - ${{ matrix.dir }}
+          path: examples/${{ matrix.dir }}/main.log


### PR DESCRIPTION
This PR adds a GitHub Action to test whether example files compile using [xu-cheng/latex-action@v2](https://github.com/xu-cheng/latex-action).

The subdirectories of examples are gathered with the `find_examples` job and added to `strategy:matrix`.

Currently, two of the examples, _documentation_ and _machine_learning_project_ fail and I haven't been to solve the issues with those.

Closes #162 