### PR TITLE
kaohandt.cls: Fix #174 by commenting out l.100 as suggested

### DIFF
--- a/kaohandt.cls
+++ b/kaohandt.cls
@@ -97,7 +97,7 @@
 %	NUMBERING
 %----------------------------------------------------------------------------------------
 
-\setcounter{secnumdepth}{\kao@secnumdepth} % Set section numbering depth
+%\setcounter{secnumdepth}{\kao@secnumdepth} % Set section numbering depth
 
 \counterwithin*{sidenote}{section} % Uncomment to reset the sidenote counter at each section
 %\counterwithout{sidenote}{section} % Uncomment to have one sidenote counter for the whole document


### PR DESCRIPTION
This change fixes an error reported by another user (ratmice) in https://github.com/fmarotta/kaobook/issues/174 where compilation fails with kaohandt.cls (they call it kaohandt.sty by mistake).  It looks like the corresponding statement in kaobook.cls (l.256) has already been commented out, so I think this change (as they suggest) is OK.

But to be sure, I tried compiling the minimal_report example with a few settings of the secnumdepth class option (including commented out per default), both with and without this change.  Compilation seems to fail without this change, and succeed (and look reasonable) with it.