### PR TITLE
kaobiblio: fix \sideparencite command (was not printing in margin)

### DIFF
--- a/kaobiblio.sty
+++ b/kaobiblio.sty
@@ -282,23 +282,23 @@
 	% With this we print the marker in the text and add the item to the bibliography at the end
 	\IfBooleanTF#1%
 		{\IfNoValueOrEmptyTF{#3}%
-			{\parencite*{#5}}%
+			{\parencite*{#5}\kaobiblio@sidecite{#5}}%
 			{\IfNoValueOrEmptyTF{#4}%
 				{\IfNoValueTF{#4}%
-					{\def\@tempa{\parencite*[#3]{#5}}}%
-					{\def\@tempa{\parencite*[#3][]{#5}}}% postnote is empty, so pass empty postnote
+					{\def\@tempa{\parencite*[#3]{#5}\kaobiblio@sidecite{#5}}}%
+					{\def\@tempa{\parencite*[#3][]{#5}\kaobiblio@sidecite{#5}}}% postnote is empty, so pass empty postnote
 				}%
-				{\def\@tempa{\parencite*[#3][#4]{#5}}}%
+				{\def\@tempa{\parencite*[#3][#4]{#5}\kaobiblio@sidecite{#5}}}%
 			}%
 		}%
 		{\IfNoValueOrEmptyTF{#3}%
-			{\def\@tempa{\parencite{#5}}}%
+			{\def\@tempa{\parencite{#5}\kaobiblio@sidecite{#5}}}%
 			{\IfNoValueOrEmptyTF{#4}%
 				{\IfNoValueTF{#4}%
-					{\def\@tempa{\parencite[#3]{#5}}}%
-					{\def\@tempa{\parencite[#3][]{#5}}}% postnote is empty, so pass empty postnote
+					{\def\@tempa{\parencite[#3]{#5}\kaobiblio@sidecite{#5}}}%
+					{\def\@tempa{\parencite[#3][]{#5}\kaobiblio@sidecite{#5}}}% postnote is empty, so pass empty postnote
 				}%
-				{\def\@tempa{\parencite[#3][#4]{#5}}}%
+				{\def\@tempa{\parencite[#3][#4]{#5}\kaobiblio@sidecite{#5}}}%
 			}%
 		}%
 	\ifkaobiblio@addspace%


### PR DESCRIPTION
The `\sideparencite` helper command was indeed calling `\parencite` but without adding anything to the side margin.

This change fixes it in [my document](https://github.com/Dettorer/synva-dissertation/commit/8daae6f6257cbc5e28a9c49a2d8036d460cc859f) but I'm not familiarized enough with the kaobook codebase to be sure of what I'm doing, so please don't hesitate to ask me to improve this PR.

What I did was basically mimick the way `\sidetextcite` combines the functionalities of `\textcite` and `\sidecite` and try to make this variant do the same.

I don't personally use it but `\sidesupercite` seems a bit faulty too, it adds something to the side margin but not with the same level of details, should I try and make it look like other citation types as well?