### PR TITLE
uniform formatting for sidecitation

### DIFF
--- a/kaobiblio.sty
+++ b/kaobiblio.sty
@@ -147,7 +147,7 @@
 
 % Command to format the marginnote created for cited items
 \NewDocumentCommand{\formatmargincitation}{m}{% The parameter is a single citation key
-	\parencite{#1}: \citeauthor*{#1} (\citeyear{#1}), \citetitle{#1}%
+	\parencite{#1}: \citeauthor*{#1} (\citeyear{#1}), \citefield{#1}[emph]{title}%
 }
 
 % Command to format the marginnote created for supercited items


### PR DESCRIPTION
This pull request enforces a uniform formatting of the title field in the `sidecite` command.

Due to the way the `sidecite` command is implemented, the titles are not printed in a uniform way if the style used formats them differently. According to the first answer [here](https://tex.stackexchange.com/questions/462133/remove-quotation-marks-from-style) (last paragraphs), this is a common feature in many citation style. While it might be meaningful in the bibliography, I found that this non-uniformity leaked into the `sidecite` command because of the use of `citetitle`, which reuses the style present there. In my humble opinion, it is disrupting there, since we now have citations which are all in the same format, *except for the title formatting*. This pull-request fixes this by resorting to the lower level `citefield` which one can use to force a format. In particular, it does *not* modify formatting anywhere else in the document.

It seems like `formatmarginsupercitation` would benefit from the same modification, but it does not currently have a `title` field, is that intentional? Also, maybe the `author` and/or `year` would benefit from the same uniformization. But I believe that style inconsistency is less likely there, and forcing a specific style would be a bad idea for consistency with the bibliography. In the same vein, one might want to use something else than the `emph` format, again for consistency with the bibliography. But I do not know how one might do that… Feel free to hack those on top of my PR if needed!