### PR TITLE
Fixing figure caption

### DIFF
--- a/kao.sty
+++ b/kao.sty
@@ -548,7 +548,7 @@
 	\marginskip{\kaomarginskipabove}%
 	\begin{lrbox}{\@sidenotes@marginfigurebox}%
 	\begin{minipage}{\marginparwidth}%
-		\captionsetup{type=figure}%
+	\captionsetup{type=figure,labelsep=space}%
 }{%
 	\end{minipage}%
 	\end{lrbox}%
@@ -655,6 +655,7 @@
 \captionsetup{
 	format=margin, % Use the style previously declared
 	strut=no,%
+  labelsep=space, % to avoid .: in figure captions
 	%hypcap=true, % Links point to the top of the figure
 	singlelinecheck=false,%
 	%width=\marginparwidth,


### PR DESCRIPTION
Currently the figure captions are of the form "Figure 3.1.:", which seems weird to me: why the point followed by a column? This PR removes that in the `sidefigure` and `figure*` environments, it might need adjustments for other kinds of floats as well. Please add a commit to this PR if this is the case!