### PR TITLE
Print "nodate" in \sidecite if year is unspecified

### DIFF
--- a/kaobiblio.sty
+++ b/kaobiblio.sty
@@ -147,12 +147,12 @@
 
 % Command to format the marginnote created for cited items
 \NewDocumentCommand{\formatmargincitation}{m}{% The parameter is a single citation key
-	\parencite{#1}: \citeauthor*{#1} (\citeyear{#1}), \citefield{#1}[emph]{title}%
+	\parencite{#1}: \citeauthor*{#1} (\iffieldundef{year}{\bibsstring{nodate}}{\printfield{year}}), \citefield{#1}[emph]{title}%
 }
 
 % Command to format the marginnote created for supercited items
 \NewDocumentCommand{\formatmarginsupercitation}{m}{% The parameter is a single citation key
-	\supercite{#1} \citeauthor*{#1} (\citeyear{#1})%
+	\supercite{#1} \citeauthor*{#1} (\iffieldundef{year}{\bibsstring{nodate}}{\printfield{year}})%
 }
 
 % The following command needs to be redefined every time \sidecite is called in order for \DeclareCiteCommand's wrapper to work correctly


### PR DESCRIPTION
Before this change, by using `\sidecite` for an entry where `year` is unspecified, I get:
> [1]: Author (), Title

and with this change, I get:

> [1]: Author (n.d.), Title

where "n.d." comes from the "nodate" localization string.