### PR TITLE
Don't force "modern" fonts with XeLaTeX / LuaTex

### DIFF
--- a/examples/documentation/main.tex
+++ b/examples/documentation/main.tex
@@ -31,6 +31,7 @@
 	%open=any, % If twoside=true, uncomment this to force new chapters to start on any page, not only on right (odd) pages
 	%chapterentrydots=true, % Uncomment to output dots from the chapter name to the page number in the table of contents
 	numbers=noenddot, % Comment to output dots after chapter numbers; the most common values for this option are: enddot, noenddot and auto (see the KOMAScript documentation for an in-depth explanation)
+	fontmethod=tex, % Can also use "modern" with XeLaTeX or LuaTex; "tex" is the default for PdfLaTex, and "modern" is the default for those two.
 ]{kaobook}
 
 %----------------------------------------------------------------------------------------

--- a/kao.sty
+++ b/kao.sty
@@ -1360,7 +1360,6 @@
 
 % Special gliphs
 \RequirePackage{ccicons} % Creative Commons icons
-\RequirePackage{metalogo} % XeTeX logo
 
 % Index, glossary and nomenclature
 \RequirePackage{imakeidx}

--- a/kao.sty
+++ b/kao.sty
@@ -16,7 +16,7 @@
 \RequirePackage{etoolbox} % Easy programming to modify TeX stuff
 \RequirePackage{calc} % Make calculations
 \RequirePackage[usenames,dvipsnames,table]{xcolor} % Colours
-\RequirePackage{iftex} % Check wether XeTeX is being used
+\RequirePackage{iftex} % Check whether XeTeX is being used
 \RequirePackage{xifthen} % Easy conditionals
 \RequirePackage{options} % Manage class options
 \RequirePackage{xparse} % Parse arguments for macros

--- a/kao.sty
+++ b/kao.sty
@@ -1,7 +1,7 @@
 \ProvidesPackage{kao}
 
 %----------------------------------------------------------------------------------------
-%	KAO-SPECIFIC OPTIONS
+%	DECLARE KAO
 %----------------------------------------------------------------------------------------
 
 \DefineFamily{kao}% Define the family name
@@ -13,6 +13,7 @@
 %	USEFUL PACKAGES AND COMMANDS
 %----------------------------------------------------------------------------------------
 
+\RequirePackage{kvoptions} % Handle package options
 \RequirePackage{etoolbox} % Easy programming to modify TeX stuff
 \RequirePackage{calc} % Make calculations
 \RequirePackage[usenames,dvipsnames,table]{xcolor} % Colours
@@ -33,6 +34,39 @@
 	\let\Ifthispageodd\ifthispageodd%
 }
 
+%----------------------------------------------------------------------------------------
+%	KAO-SPECIFIC OPTIONS
+%----------------------------------------------------------------------------------------
+
+% Set up the package options
+\SetupKeyvalOptions{
+	family = kao,
+	prefix = kao@
+}
+
+% https://tex.stackexchange.com/questions/47576/combining-ifxetex-and-ifluatex-with-the-logical-or-operation
+% Introduce a command to find out whether the compiler is XeTeX or LuaTeX
+\newif\ifxetexorluatex
+\ifxetex
+	\xetexorluatextrue
+\else
+	\ifluatex
+		\xetexorluatextrue
+	\else
+		\xetexorluatexfalse
+	\fi
+\fi
+
+\ifxetexorluatex
+	\newcommand{\kao@defaultfontmethod}{modern}
+\else
+	\newcommand{\kao@defaultfontmethod}{tex}
+\fi
+
+% Set default based on rendering engine
+\DeclareStringOption[\kao@defaultfontmethod]{fontmethod}
+
+\ProcessKeyvalOptions{kao}
 
 %----------------------------------------------------------------------------------------
 %	TITLE AND AUTHOR MACROS
@@ -1038,20 +1072,7 @@
 %	ENCODING AND FONTS
 %----------------------------------------------------------------------------------------
 
-% https://tex.stackexchange.com/questions/47576/combining-ifxetex-and-ifluatex-with-the-logical-or-operation
-% Introduce a command to find out whether the compiler is XeTeX or LuaTeX
-\newif\ifxetexorluatex
-\ifxetex
-	\xetexorluatextrue
-\else
-	\ifluatex
-		\xetexorluatextrue
-	\else
-		\xetexorluatexfalse
-	\fi
-\fi
-
-\ifxetexorluatex
+\newcommand{\kao@fontmethodModern}{%
 	\RequirePackage{amssymb} % Must be loaded before unicode-math
 	\RequirePackage[force]{filehook} % Fixes an error
 	\RequirePackage{unicode-math} % Math fonts in xetexorluatex
@@ -1068,8 +1089,9 @@
 	\ifluatex
 	\else
 		\RequirePackage{morewrites} % Fix some errors related to floats (not necessary with LuaLaTeX
-	\fi
-\else
+	\fi%
+}
+\newcommand{\kao@fontmethodTex}{%
 	\RequirePackage[utf8]{inputenc} % utf8 encoding in the input (.tex) file
 	\RequirePackage[T1]{fontenc} % utf8 encoding in the output (.pdf) file
 
@@ -1079,7 +1101,19 @@
 	\RequirePackage[scaled=.85]{beramono} % Monospace font
 	\RequirePackage[scr=rsfso,cal=boondoxo]{mathalfa} % Mathcal from STIX, unslanted a bit
 	\RequirePackage{morewrites} % Fix some errors related to floats
-\fi
+}
+
+\ifthenelse%
+	{\equal{modern}{\kao@fontmethod}}{\kao@fontmethodModern}%
+{\ifthenelse%
+	{\equal{tex}{\kao@fontmethod}}{\kao@fontmethodTex}%
+{
+	\PackageError{kao}{%
+		Invalid fontmethod choice \kao@fontmethod.%
+	}{%
+		Should be one of "modern" or "tex"%
+	}
+}}
 
 % When using the Palatino (newpxtext) font, it is better to use a 
 % slightly larger stretch.


### PR DESCRIPTION
Create a new `fontmethod` kvoption with today's defaulting rules that allows controlling this.