### PR TITLE
Background Color Fix for Theorems

### DIFF
--- a/kaotheorems.sty
+++ b/kaotheorems.sty
@@ -16,15 +16,15 @@
 % If only the 'background' option is specified, all types of theorem will have that background. If more specific options are set, the previous option will be overwritten.
 \newcommand{\kaotheorems@defaultbg}{Goldenrod!45!white}
 \DeclareStringOption[\kaotheorems@defaultbg]{background}
-\DeclareStringOption[\kaotheorems@defaultbg]{theorembackground}
-\DeclareStringOption[\kaotheorems@defaultbg]{propositionbackground}
-\DeclareStringOption[\kaotheorems@defaultbg]{lemmabackground}
-\DeclareStringOption[\kaotheorems@defaultbg]{corollarybackground}
-\DeclareStringOption[\kaotheorems@defaultbg]{definitionbackground}
-\DeclareStringOption[\kaotheorems@defaultbg]{assumptionbackground}
-\DeclareStringOption[\kaotheorems@defaultbg]{remarkbackground}
-\DeclareStringOption[\kaotheorems@defaultbg]{examplebackground}
-\DeclareStringOption[\kaotheorems@defaultbg]{exercisebackground}
+\DeclareStringOption[\kaotheorems@background]{theorembackground}
+\DeclareStringOption[\kaotheorems@background]{propositionbackground}
+\DeclareStringOption[\kaotheorems@background]{lemmabackground}
+\DeclareStringOption[\kaotheorems@background]{corollarybackground}
+\DeclareStringOption[\kaotheorems@background]{definitionbackground}
+\DeclareStringOption[\kaotheorems@background]{assumptionbackground}
+\DeclareStringOption[\kaotheorems@background]{remarkbackground}
+\DeclareStringOption[\kaotheorems@background]{examplebackground}
+\DeclareStringOption[\kaotheorems@background]{exercisebackground}
 
 \ProcessKeyvalOptions{kaotheorems} % Process the options
 


### PR DESCRIPTION
The examples [mention](https://github.com/fmarotta/kaobook/blob/ebdb7cfe7d78c9d8c9604428216bfd5bbe16c062/examples/documentation/chapters/mathematics.tex#L121) that the background color for theorems and other similar math environments can be changed by settings the `background` option. While the more specific options, e.g., `theorembackground`, work as expected, the `background` option does not have any effect, which this PR fixes.