### PR TITLE
Binding correction compatibility

### DIFF
--- a/examples/documentation/chapters/options.tex
+++ b/examples/documentation/chapters/options.tex
@@ -23,6 +23,12 @@ the paragraphs are separated by space,\sidenote[][-7mm]{To be precise,
 they are separated by half a line worth of space: the \Option{parskip} 
 value is \enquote{half}.} not marked by indentation.
 
+The \KOMAScript\xspace option \Option{BCOR} (binding correction) is supported; 
+its value is forwarded to \Package{geometry} as a binding offset so that 
+inner margins are enlarged automatically. For example,
+\lstinline|\documentclass[BCOR=8mm]{kaobook}| adds an 8\,mm correction to 
+the inner margin.
+
 \section{\Class{kao} Options}
 
 In the future I plan to add more options to set the paragraph formatting 

--- a/kao.sty
+++ b/kao.sty
@@ -166,11 +166,26 @@
 \@ifclasswith{\@baseclass}{a4paperlandscape}{\setlength{\hscale}{1.414mm}\setlength{\vscale}{0.707mm}}{}
 \@ifclasswith{\@baseclass}{169paperlandscape}{\setlength{\hscale}{1.414mm}\setlength{\vscale}{0.562mm}}{}
 
+% Create a length to store the binding correction from KOMAScript
+\newlength{\kao@bcor}
+\setlength{\kao@bcor}{0pt}
+
 % Set the default page layout
 \RequirePackage[
 	paperwidth=210\hscale,
 	paperheight=297\vscale,
 ]{geometry}
+
+% Extract BCOR value from KOMAScript immediately after geometry is loaded
+% This must happen before any \newgeometry calls
+% Use ta@bcor which is KOMAScript's internal register for BCOR
+\AtEndPreamble{%
+	\@ifundefined{ta@bcor}{%
+		\setlength{\kao@bcor}{0pt}%
+	}{%
+		\setlength{\kao@bcor}{\ta@bcor}%
+	}%
+}
 
 % Command to choose among the three possible layouts
 \DeclareDocumentCommand{\pagelayout}{m}{%
@@ -191,6 +206,7 @@
 % Layout #1: large margins
 \newcommand{\marginlayout}{%
 	\newgeometry{
+		bindingoffset=\kao@bcor,
 		top=27.4\vscale,
 		bottom=27.4\vscale,
 		inner=24.8\hscale,
@@ -205,6 +221,7 @@
 % Layout #2: small, symmetric margins
 \newcommand{\widelayout}{%
 	\newgeometry{
+		bindingoffset=\kao@bcor,
 		top=27.4\vscale,
 		bottom=27.4\vscale,
 		inner=24.8\hscale,


### PR DESCRIPTION
Thank you very much for this wonderful template.

The komascript originally offers the option `BCOR` to get extra space for the (book) binding.

This PR adds support for this option for the two layouts provided by kaobook.