### PR TITLE
Removed the usenames options of the xcolor package

### DIFF
--- a/kao.sty
+++ b/kao.sty
@@ -16,7 +16,7 @@
 \RequirePackage{kvoptions} % Handle package options
 \RequirePackage{etoolbox} % Easy programming to modify TeX stuff
 \RequirePackage{calc} % Make calculations
-\RequirePackage[usenames,dvipsnames,table]{xcolor} % Colours
+\RequirePackage[dvipsnames,table]{xcolor} % Colours
 \RequirePackage{iftex} % Check whether XeTeX is being used
 \RequirePackage{xifthen} % Easy conditionals
 \RequirePackage{options} % Manage class options


### PR DESCRIPTION
Since xcolor v2, the `usenames` package's option is no longer needed. And at v3 it became obsolete. This update removes the warning from the compilation log.